### PR TITLE
Add proper ethash sealing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tests/
+ethash/

--- a/blockgen.go
+++ b/blockgen.go
@@ -1,18 +1,21 @@
 package main
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 )
 
-func genSimpleChain() (*core.Genesis, []*types.Block) {
+// genSimpleChain generates a short chain with a few basic transactions.
+func genSimpleChain(engine consensus.Engine) (*core.Genesis, []*types.Block) {
 	var (
 		keyHex  = "9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"
 		key, _  = crypto.HexToECDSA(keyHex)
@@ -28,9 +31,26 @@ func genSimpleChain() (*core.Genesis, []*types.Block) {
 		genesis = gspec.MustCommit(gendb)
 		signer  = types.LatestSigner(gspec.Config)
 	)
-	chain, _ := core.GenerateChain(gspec.Config, genesis, ethash.NewFaker(), gendb, 3, func(i int, gen *core.BlockGen) {
+	sealingEngine := sealingEngine{engine}
+	chain, _ := core.GenerateChain(gspec.Config, genesis, sealingEngine, gendb, 3, func(i int, gen *core.BlockGen) {
 		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(address), address, big.NewInt(1000), params.TxGas, gen.BaseFee(), nil), signer, key)
 		gen.AddTx(tx)
 	})
 	return gspec, chain
+}
+
+// sealingEngine overrides FinalizeAndAssemble and performs sealing in-place.
+type sealingEngine struct{ consensus.Engine }
+
+func (e sealingEngine) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+	block, err := e.Engine.FinalizeAndAssemble(chain, header, state, txs, uncles, receipts)
+	if err != nil {
+		return nil, err
+	}
+	sealedBlock := make(chan *types.Block, 1)
+	if err = e.Engine.Seal(nil, block, sealedBlock, nil); err != nil {
+		return nil, err
+	}
+	fmt.Printf("sealing block %d\n", header.Number.Uint64())
+	return <-sealedBlock, nil
 }

--- a/main.go
+++ b/main.go
@@ -18,8 +18,10 @@ type Args struct {
 	ClientType string `arg:"--client" help:"client type" default:"geth"`
 	ClientBin  string `arg:"--bin" help:"path to client binary" default:"geth"`
 	OutDir     string `arg:"--out" help:"directory where test fixtures will be written" default:"tests"`
+	Ethash     bool   `args:"--ethash" help:"seal blocks using proof-of-work"`
+	EthashDir  string `args:"--ethashdir" help:"directory to store ethash dag (empty for in-memory only)"`
 	Verbose    bool   `arg:"-v,--verbose" help:"verbosity level of rpctestgen"`
-	LogLevel   string `arg:"--log-level" help:"log level of client" default:"info"`
+	LogLevel   string `arg:"--loglevel" help:"log level of client" default:"info"`
 }
 
 func main() {
@@ -32,7 +34,6 @@ func main() {
 	if err := runGenerator(ctx); err != nil {
 		exit(err)
 	}
-
 }
 
 func exit(err error) {

--- a/testgen/generators.go
+++ b/testgen/generators.go
@@ -53,10 +53,20 @@ var EthGetBlockByNumber = MethodTests{
 			"gets block 0",
 			ethGetBlockByNumberGenesis,
 		},
+		{
+			"get-block-n",
+			"gets block 2",
+			ethGetBlockByNumberN,
+		},
 	},
 }
 
 func ethGetBlockByNumberGenesis(ctx context.Context, eth *ethclient.Client) error {
 	_, err := eth.BlockByNumber(ctx, common.Big0)
+	return err
+}
+
+func ethGetBlockByNumberN(ctx context.Context, eth *ethclient.Client) error {
+	_, err := eth.BlockByNumber(ctx, common.Big2)
 	return err
 }


### PR DESCRIPTION
Some clients in hive don't readily support `--fakepow`, so we'll just seal the generated chain with a very low difficulty proof-of-work.