### PR TITLE
Generate tests using chain from file

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,8 +18,9 @@ type Args struct {
 	ClientType string `arg:"--client" help:"client type" default:"geth"`
 	ClientBin  string `arg:"--bin" help:"path to client binary" default:"geth"`
 	OutDir     string `arg:"--out" help:"directory where test fixtures will be written" default:"tests"`
-	Ethash     bool   `args:"--ethash" help:"seal blocks using proof-of-work"`
-	EthashDir  string `args:"--ethashdir" help:"directory to store ethash dag (empty for in-memory only)"`
+	Ethash     bool   `arg:"--ethash" help:"seal blocks using proof-of-work"`
+	EthashDir  string `arg:"--ethashdir" help:"directory to store ethash dag (empty for in-memory only)"`
+	ChainDir   string `arg:"--chain" help:"path to directory with chain.rlp and genesis.json"`
 	Verbose    bool   `arg:"-v,--verbose" help:"verbosity level of rpctestgen"`
 	LogLevel   string `arg:"--loglevel" help:"log level of client" default:"info"`
 

--- a/testgen/generators.go
+++ b/testgen/generators.go
@@ -52,14 +52,17 @@ var EthBlockNumber = MethodTests{
 		{
 			"simple-test",
 			"retrieves the client's current block number",
-			ethBlockNumber,
+			func(ctx context.Context, t *T) error {
+				got, err := t.eth.BlockNumber(ctx)
+				if err != nil {
+					return err
+				} else if want := t.chain.CurrentHeader().Number.Uint64(); got != want {
+					return fmt.Errorf("unexpect current block number (got: %d, want: %d)", got, want)
+				}
+				return nil
+			},
 		},
 	},
-}
-
-func ethBlockNumber(ctx context.Context, t *T) error {
-	_, err := t.eth.BlockNumber(ctx)
-	return err
 }
 
 // EthGetBlockByNumber stores a list of all tests against the method.


### PR DESCRIPTION
Loads an existing `chain.rlp` with `--chain=directory` before filling tests.