### PR TITLE
Makefile: rm dropped ethash flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ lint:
 	staticcheck ./...
 
 fill: build
-	./rpctestgen  --ethash --ethashdir=ethash
+	./rpctestgen


### PR DESCRIPTION
That fill command is kinda bare now! Not sure if you want to keep it :d